### PR TITLE
Check for secrets with gitleaks and build docker image with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2.1
+
+orbs:
+  docker-publish: upenn-libraries/docker-publish@0.1.0
+  gitleaks: upenn-libraries/gitleaks@0.1.1
+
+workflows:
+  build_and_test:
+    jobs:
+      - gitleaks/check_local:
+          image: quay.io/upennlibraries/gitleaks:v1.24.0
+          options: --redact
+      - docker-publish/publish:
+          context: quay.io
+          registry: quay.io
+          image: upennlibraries/metridoc
+          label_prefix: edu.upenn.library
+          requires:
+            - gitleaks/check_local


### PR DESCRIPTION
We now have images building and testing automatically with CircleCI under the Metridoc organization. 📊 