### PR TITLE
Create contributing, onboarding, and offboarding docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,7 @@
 .gitignore
 Dockerfile
 docker-compose.yml
-README.md
+*.md
 
 log/**/*
 tmp/**/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+1. Branch off of `staging`.
+2. Test building the Docker image and running the application locally.
+3. Submit a PR. A maintainer will be notified and your PR will be reviewed once all tests pass in [CircleCI](https://circleci.com/gh/metridoc/metridoc-rails) and there are no merge conflicts.
+4. The maintainer will review and provide feedback. Once they approve your PR the maintainer will merge your commits.
+5. Deploy your changes as soon as you are safely and conveniently able to do so.
+
+## For Maintainers
+
+Maintainers may merge their own PRs if no other maintainers are available. Code review is still strongly encouraged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 2. Test building the Docker image and running the application locally.
 3. Submit a PR. A maintainer will be notified and your PR will be reviewed once all tests pass in [CircleCI](https://circleci.com/gh/metridoc/metridoc-rails) and there are no merge conflicts.
 4. The maintainer will review and provide feedback. Once they approve your PR the maintainer will merge your commits.
-5. Deploy your changes as soon as you are safely and conveniently able to do so.
+5. Deploy your changes as soon as you are able to do so.
 
 ## For Maintainers
 

--- a/OFFBOARDING.md
+++ b/OFFBOARDING.md
@@ -1,0 +1,8 @@
+# Offboarding
+
+Developers who are no longer contributing to the development of the Metridoc application should be offboarded and should have relevant group memberships and permissions revoked by a team member with admin privileges.
+
+## Offboarder Tasks
+
+- Remove the developer from the Developers team in the [Metridoc](https://github.com/metridoc) GitHub organization.
+- Remove the developer from the metridoc team in the [UPenn Libraries](https://quay.io/organization/upennlibraries) Quay.io organization.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,17 @@
+# Onboarding
+
+Developers who need to contribute to the development of the Metridoc application should be onboarded and given necessary group memberships and permissions by a team member with admin privileges.
+
+## Onboarder Tasks
+
+- Invite the developer to the [Metridoc](https://github.com/metridoc) GitHub organization and add them to the Developers team.
+- Invite the developer to the [UPenn Libraries](https://quay.io/organization/upennlibraries) Quay.io organization and add them to the metridoc team.
+- Invite the developer to the #metridoc and #metridoc-notifications Slack channels.
+
+## Onboardee Tasks
+
+- Create [GitHub](https://github.com/), [Quay.io](https://quay.io/) and [CircleCI](https://circleci.com/) accounts if you haven't already. You can use your GitHub account to sign up for Quay.io and CircleCI.
+- Accept the invite for the [Metridoc](https://github.com/metridoc) GitHub organization and teams.
+- Accept the invite for the [UPenn Libraries](https://quay.io/organization/upennlibraries) Quay.io organization and teams.
+- Follow the [`metridoc-rails`](https://circleci.com/gh/metridoc/metridoc-rails) project on CircleCI.
+- Install [Docker](https://docs.docker.com/install/) on your workstation.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -15,3 +15,6 @@ Developers who need to contribute to the development of the Metridoc application
 - Accept the invite for the [UPenn Libraries](https://quay.io/organization/upennlibraries) Quay.io organization and teams.
 - Follow the [`metridoc-rails`](https://circleci.com/gh/metridoc/metridoc-rails) project on CircleCI.
 - Install [Docker](https://docs.docker.com/install/) on your workstation.
+- Review the following docs in this repo:
+  - [README](README.md)
+  - [CONTRIBUTING](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ### Using Docker
 
+The process below will work for local development but the setup process available in the [Metridoc configuration management repo](https://github.com/upenn-libraries/metridoc_config#local-development-for-metridoc) is recommended. It simplifies local setup, provides a working development configuration, manages most interactions with Docker, and more closely resembles the production config.
+
 #### Requirements
 
 - Docker 18.06+
@@ -25,9 +27,9 @@ Create Docker secrets
 ```
 # Modify `config/database.yml` and `config/secrets.yml` as necessary
 # `metridoc_db_password` secret must match `password` in `config/database.yml`
-echo 'password' | docker secret create metridoc_db_password -
+echo 'metridoc_development' | docker secret create metridoc_db_password -
 cat config/database.yml | docker secret create metridoc_rails_db_config -
-cat config/secrets.examples.yml | docker secret create metridoc_rails_secrets_config -
+cat config/secrets.yml | docker secret create metridoc_rails_secrets_config -
 ```
 
 Deploy Docker stack

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # README
 
-## Setup development environment
-
-    brew install freetds # this may resolve some dependencies needed by tiny_tds, but not all of us had that problem.
-    cp config/database.yml.example config/database.yml # modify as necessary
-    rake db:create
+## Setting Up a Local Development Environment
 
 ### Using Docker
 
@@ -53,6 +49,12 @@ docker exec -it $(docker ps -q -f name=metridoc_app) /bin/bash
 #### Applying Changes
 
 To apply changes to your local Docker containers, rebuild the `metridoc` image and then redeploy the Docker stack.
+
+### Using Homebrew
+
+    brew install freetds # this may resolve some dependencies needed by tiny_tds, but not all of us had that problem.
+    bundle install
+    bundle exec rake db:setup
 
 ## Load a DB snapshot to staging
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,8 +4,8 @@ default: &default
 development:
   <<: *default
   database: metridoc_development
-  username: kate
-  password:
+  username: metridoc_development
+  password: metridoc_development
 
 test:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,14 @@ version: '3.7'
 
 services:
   app:
-    image: metridoc:staging
+    image: metridoc
     environment:
       PASSENGER_APP_ENV: ${RAILS_ENV}
       RAILS_ENV:
     ports:
       - '80:80'
     secrets:
-      - source: metridoc_rails_db_config_3
+      - source: metridoc_rails_db_config
         target: /home/app/webapp/config/database.yml
         uid: '9999'
         gid: '9999'
@@ -19,14 +19,12 @@ services:
         uid: '9999'
         gid: '9999'
         mode: 0440
-    volumes:
-      - staging_data:/var/lib/
   db:
     image: postgres:10.5-alpine
     environment:
       POSTGRES_PASSWORD_FILE: /run/secrets/metridoc_db_password
     ports:
-      - '5432:5432' 
+      - '5432:5432'
     secrets:
       - metridoc_db_password
     volumes:
@@ -35,11 +33,10 @@ services:
 secrets:
   metridoc_db_password:
     external: true
-  metridoc_rails_db_config_3:
+  metridoc_rails_db_config:
     external: true
   metridoc_rails_secrets_config:
     external: true
 
 volumes:
   db_data:
-  staging_data:


### PR DESCRIPTION
I set up these docs after taking some notes while onboarding another dev. The contributing workflow is based around the process I've seen thus far which works well. I also added on/offboarding docs to help out with housekeeping 🌬 