### PR TITLE
Add healthcheck for Metridoc container

### DIFF
--- a/ansible/roles/metridoc_manager/files/docker-compose.yml
+++ b/ansible/roles/metridoc_manager/files/docker-compose.yml
@@ -80,6 +80,12 @@ services:
       YALE_ILLIAD_MSSQL_PWD:
       YALE_ILLIAD_MSSQL_UID:
 
+    healthcheck:
+      test: ["CMD", "/home/app/webapp/healthcheck.rb"]
+      interval: 30s
+      timeout: 15s
+      retries: 3
+      start_period: 1m30s
     networks:
       - app
       - database

--- a/healthcheck.rb
+++ b/healthcheck.rb
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+require 'net/http'
+
+uri = URI('http://localhost/')
+res = Net::HTTP.get_response(uri)
+
+exit res.is_a?(Net::HTTPOK) ? 0 : 1

--- a/webapp.conf
+++ b/webapp.conf
@@ -1,3 +1,5 @@
+passenger_pre_start http://localhost:80/;
+
 server {
   listen 80;
   server_name _;
@@ -5,6 +7,8 @@ server {
 
   passenger_enabled on;
   passenger_user app;
+  passenger_max_preloader_idle_time 0;
+  passenger_min_instances 1;
 
   # Rails asset pipeline support.
   location ~ "^/assets/.+-([0-9a-f]{32}|[0-9a-f]{64})\..+" {


### PR DESCRIPTION
We can check whether the application is capable of actually serving a request (in this case loading the index page) to let swarm know if it needs to kill and restart the task. This could catch some application-level bugs that don't cause the foreground process to fail and allow swarm to stop a rolling update before it hits all users. 🛑 

A supporting change for this is preloading the app when the Passenger process starts so that initial healthchecks can pass. The total time to do this is about 1m30s, hence the `start_period` setting. ⏱ 