### PR TITLE
Upgrade docker-publish and gitleaks orbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  docker-publish: upenn-libraries/docker-publish@0.1.0
-  gitleaks: upenn-libraries/gitleaks@0.1.1
+  docker-publish: upenn-libraries/docker-publish@0.2.0
+  gitleaks: upenn-libraries/gitleaks@0.1.2
 
 commands:
   molecule_test:


### PR DESCRIPTION
No major changes in any of these, just updating some of their orb dependencies under the hood. 🔧 🚗 