### PR TITLE
Hotfix alma csv data source type

### DIFF
--- a/app/admin/alma.rb
+++ b/app/admin/alma.rb
@@ -1,0 +1,10 @@
+ActiveAdmin.register_page "Alma" do
+  content do
+    resource_collection = ActiveAdmin.application.namespaces[:admin].resources
+    resources = resource_collection.select { |resource| resource.respond_to? :resource_class }
+    resources = resources.select{|r| /^Alma::/.match(r.resource_name.name) }
+    resources = resources.sort{|a,b| a.resource_name.human <=> b.resource_name.human }
+
+    render partial: 'index', locals: {resources: resources}
+  end
+end

--- a/app/admin/alma_circulations.rb
+++ b/app/admin/alma_circulations.rb
@@ -1,0 +1,4 @@
+ActiveAdmin.register Alma::Circulation do
+  menu false
+  permit_params :policy_name, :barcode, :item_id, :permanent_call_number, :classification_code, :lc_group1, :lc_group2, :lc_group3, :lc_group4, :lc_group5, :mms_id, :title, :title_normalized, :author, :bibliographic_material_type, :physical_item_material_type, :bibliographic_resource_type, :isbn, :isbn_normalized, :issn, :issn_normalized, :oclc_control_number_019, :oclc_control_number_035a, :oclc_control_number_035z, :oclc_control_number_az, :library_name, :location_name, :resource_sharing_library, :user_group, :statistical_category_1, :statistical_category_2, :statistical_category_3, :statistical_category_4, :statistical_category_5, :loan_year, :loan_fiscal_year, :loan_date, :due_date, :original_due_date
+end

--- a/app/models/alma/base.rb
+++ b/app/models/alma/base.rb
@@ -1,0 +1,4 @@
+class Alma::Base < ApplicationRecord
+  self.abstract_class = true
+  self.table_name_prefix = 'alma_'
+end

--- a/app/models/alma/circulation.rb
+++ b/app/models/alma/circulation.rb
@@ -1,0 +1,2 @@
+class Alma::Circulation < Alma::Base
+end

--- a/app/views/admin/alma/_index.html.haml
+++ b/app/views/admin/alma/_index.html.haml
@@ -1,0 +1,3 @@
+%ul
+  - resources.each do |resource|
+    %li= link_to resource.resource_name.human, "/admin/#{resource.resource_name.param_key.pluralize}"

--- a/config/data_sources/upenn_alma/01_circulation.yml
+++ b/config/data_sources/upenn_alma/01_circulation.yml
@@ -1,0 +1,50 @@
+---
+load_sequence: 1
+target_model: "Alma::Circulation"
+target_adapter: "csv"
+file_name: "alma_circulation_daily.csv"
+column_mappings:
+  "Policy Name": policy_name
+  "Item Id": item_id
+  "Permanent Call Number": permanent_call_number
+  "Classification Code": classification_code
+  "LC Group1": lc_group1
+  "LC Group2": lc_group2
+  "LC Group3": lc_group3
+  "LC Group4": lc_group4
+  "LC Group5": lc_group5
+  "Dewey Number": dewey_number
+  "Dewey Group1": dewey_group1
+  "Dewey Group2": dewey_group2
+  "Dewey Group3": dewey_group3
+  "MMS Id": mms_id
+  "Title": title
+  "Title (Normalized)": title_normalized
+  "Author": author
+  "Bibliographic Material Type": bibliographid_material_type
+  "Physical Item Material Type": physical_item_material_type
+  "Bibliographic Resource Type": bibliographic_resource_type
+  "ISBN": isbn
+  "ISBN (Normalized)": isbn_normalized
+  "ISSN": issn
+  "ISSN (Normalized)": issn_normalized
+  "OCLC Control Number (019)": oclc_control_number_019
+  "OCLC Control Number (035a)": oclc_control_number_035a
+  "OCLC Control Number (035z)": oclc_control_number_035z
+  "OCLC Control Number (035a+z)": oclc_control_number_035az
+  "Library Name": library_name
+  "Location Name": location_name
+  "Resource Sharing Library": resource_sharing_library
+  "User Group": user_group
+  "Statistical Category 1": statistical_category_1
+  "Statistical Category 2": statistical_category_2
+  "Statistical Category 3": statistical_category_3
+  "Statistical Category 4": statistical_category_4
+  "Statistical Category 5": statistical_category_5
+  "Loan Year": loan_year
+  "Loan Fiscal Year": loan_fiscal_year
+  "Loan Date": loan_date
+  "Due Date": due_date
+  "Original Due Date": original_due_date
+
+

--- a/config/data_sources/upenn_alma/01_circulation.yml
+++ b/config/data_sources/upenn_alma/01_circulation.yml
@@ -5,6 +5,7 @@ target_adapter: "csv"
 file_name: "alma_circulation_daily.csv"
 column_mappings:
   "Policy Name": policy_name
+  "Barcode": barcode
   "Item Id": item_id
   "Permanent Call Number": permanent_call_number
   "Classification Code": classification_code
@@ -21,7 +22,7 @@ column_mappings:
   "Title": title
   "Title (Normalized)": title_normalized
   "Author": author
-  "Bibliographic Material Type": bibliographid_material_type
+  "Bibliographic Material Type": bibliographic_material_type
   "Physical Item Material Type": physical_item_material_type
   "Bibliographic Resource Type": bibliographic_resource_type
   "ISBN": isbn

--- a/config/data_sources/upenn_alma/global.yml
+++ b/config/data_sources/upenn_alma/global.yml
@@ -1,0 +1,3 @@
+---
+target_adapter: 'csv'
+import_folder: '/tmp/upenn_alma'

--- a/db/migrate/20200319153029_create_alma_tables.rb
+++ b/db/migrate/20200319153029_create_alma_tables.rb
@@ -1,0 +1,49 @@
+class CreateAlmaTables < ActiveRecord::Migration[5.1]
+  def change
+    create_table :alma_circulations do |t|
+      t.string :policy_name
+      t.string :barcode
+      t.string :item_id
+      t.string :permanent_call_number
+      t.string :classification_code
+      t.string :lc_group1
+      t.string :lc_group2
+      t.string :lc_group3
+      t.string :lc_group4
+      t.string :lc_group5
+      t.string :dewey_number
+      t.string :dewey_group1
+      t.string :dewey_group2
+      t.string :dewey_group3
+      t.string :mms_id
+      t.string :title
+      t.string :title_normalized
+      t.string :author
+      t.string :bibliographic_material_type
+      t.string :physical_item_material_type
+      t.string :bibliographic_resource_type
+      t.string :isbn
+      t.string :isbn_normalized
+      t.string :issn
+      t.string :issn_normalized
+      t.string :oclc_control_number_019
+      t.string :oclc_control_number_035a
+      t.string :oclc_control_number_035z
+      t.string :oclc_control_number_az
+      t.string :library_name
+      t.string :location_name
+      t.string :resource_sharing_library
+      t.string :user_group
+      t.string :statistical_category_1
+      t.string :statistical_category_2
+      t.string :statistical_category_3
+      t.string :statistical_category_4
+      t.string :statistical_category_5
+      t.string :loan_year
+      t.string :loan_fiscal_year
+      t.datetime :loan_date
+      t.datetime :due_date
+      t.datetime :original_due_date
+    end
+  end
+end

--- a/db/migrate/20200319153029_create_alma_tables.rb
+++ b/db/migrate/20200319153029_create_alma_tables.rb
@@ -29,7 +29,7 @@ class CreateAlmaTables < ActiveRecord::Migration[5.1]
       t.string :oclc_control_number_019
       t.string :oclc_control_number_035a
       t.string :oclc_control_number_035z
-      t.string :oclc_control_number_az
+      t.string :oclc_control_number_035az
       t.string :library_name
       t.string :location_name
       t.string :resource_sharing_library

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -70,7 +70,7 @@ ActiveRecord::Schema.define(version: 20200319153029) do
     t.string "oclc_control_number_019"
     t.string "oclc_control_number_035a"
     t.string "oclc_control_number_035z"
-    t.string "oclc_control_number_az"
+    t.string "oclc_control_number_035az"
     t.string "library_name"
     t.string "location_name"
     t.string "resource_sharing_library"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191204143414) do
+ActiveRecord::Schema.define(version: 20200319153029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,9 +37,54 @@ ActiveRecord::Schema.define(version: 20191204143414) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "roles_mask"
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
+  end
+
+  create_table "alma_circulations", force: :cascade do |t|
+    t.string "policy_name"
+    t.string "barcode"
+    t.string "item_id"
+    t.string "permanent_call_number"
+    t.string "classification_code"
+    t.string "lc_group1"
+    t.string "lc_group2"
+    t.string "lc_group3"
+    t.string "lc_group4"
+    t.string "lc_group5"
+    t.string "dewey_number"
+    t.string "dewey_group1"
+    t.string "dewey_group2"
+    t.string "dewey_group3"
+    t.string "mms_id"
+    t.string "title"
+    t.string "title_normalized"
+    t.string "author"
+    t.string "bibliographic_material_type"
+    t.string "physical_item_material_type"
+    t.string "bibliographic_resource_type"
+    t.string "isbn"
+    t.string "isbn_normalized"
+    t.string "issn"
+    t.string "issn_normalized"
+    t.string "oclc_control_number_019"
+    t.string "oclc_control_number_035a"
+    t.string "oclc_control_number_035z"
+    t.string "oclc_control_number_az"
+    t.string "library_name"
+    t.string "location_name"
+    t.string "resource_sharing_library"
+    t.string "user_group"
+    t.string "statistical_category_1"
+    t.string "statistical_category_2"
+    t.string "statistical_category_3"
+    t.string "statistical_category_4"
+    t.string "statistical_category_5"
+    t.string "loan_year"
+    t.string "loan_fiscal_year"
+    t.datetime "loan_date"
+    t.datetime "due_date"
+    t.datetime "original_due_date"
   end
 
   create_table "bookkeeping_data_loads", force: :cascade do |t|
@@ -123,12 +168,6 @@ ActiveRecord::Schema.define(version: 20191204143414) do
     t.string "exception_code", limit: 3
     t.datetime "process_date"
     t.boolean "is_legacy", default: false, null: false
-  end
-
-  create_table "data_loads_ranges", force: :cascade do |t|
-    t.string "table_name"
-    t.datetime "start"
-    t.datetime "end"
   end
 
   create_table "ezborrow_bibliographies", force: :cascade do |t|

--- a/lib/import/task.rb
+++ b/lib/import/task.rb
@@ -178,7 +178,9 @@ module Import
 
         table_name = class_name.table_name
         password = YAML.parse_file(Rails.root + "config" + "database.yml").to_ruby[Rails.env]['password']
-        cmd = "PGPASSWORD='#{password}' psql -Upostgres -h primary-db -c \
+        username = YAML.parse_file(Rails.root + "config" + "database.yml").to_ruby[Rails.env]['username']
+        host = YAML.parse_file(Rails.root + "config" + "database.yml").to_ruby[Rails.env]['host']
+        cmd = "PGPASSWORD='#{password}' psql -U#{username} -h #{host} -c \
               \"\\copy #{table_name}(#{headers}) FROM '#{csv_file_path}' WITH DELIMITER ',' HEADER CSV\""
 
         system(cmd)


### PR DESCRIPTION
Minor changes to config file & migration. Added a regex that should strip out the BOM/U+FEFF character showing up at the start of many csv files. Also slightly modified the step for mapping preprocess output header to expected import column names.