### PR TITLE
Fix delayed job restart

### DIFF
--- a/app/models/tools/file_upload_import.rb
+++ b/app/models/tools/file_upload_import.rb
@@ -38,6 +38,10 @@ class Tools::FileUploadImport < ApplicationRecord
     import
     log "Finished processing."
     FileUploadImportMailer.with(file_upload_import: Tools::FileUploadImport.find(id)).finished_notice.deliver_now
+    rescue SignalException => se
+      log "Process terminated => #{se.message}"
+      update_columns(status: 'pending')
+      raise se
   end
 
   def calculate_rows_to_process


### PR DESCRIPTION
This change is to avoid any issues if a long executing job gets interrupted during deploy to make sure it starts safely on delayed job coming back.