### PR TITLE
Adding a hardcoded start date to ignore a bad row of data.

### DIFF
--- a/app/views/admin/consultation/_summary.html.haml
+++ b/app/views/admin/consultation/_summary.html.haml
@@ -1,5 +1,7 @@
 -# Get date range of data
 - start_date, end_date = date_range()
+-# Fix the summary start date to get rid of nonsense
+- start_date = Date.parse("2018-01-01")
 
 -# Using chartkick to create quick dashboard
 %h2 Statistics for All Library Interactions
@@ -144,7 +146,7 @@
         (The y scale is log
         %sub> 10
         )
-        
+
   %h2 Session Description
   #data-viz
     #left-col


### PR DESCRIPTION
This makes the timeline plot on the consultation summary page better, ignoring malformed rows with dates in 2002!