### PR TITLE
Revert "Update the base docker image to one with Ruby 3.2.2"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/passenger-ruby32:2.6.0
+FROM phusion/passenger-ruby27:2.3.0
 
 COPY delayed-job-log-forwarder.sh /etc/service/delayed-job-log-forwarder/run
 COPY webapp.conf /etc/nginx/sites-enabled/webapp


### PR DESCRIPTION
Reverts metridoc/metridoc-rails#329