### PR TITLE
Remove attribute - needed for rails 6 but not for rails 7?

### DIFF
--- a/app/models/springshare/libanswers/ticket.rb
+++ b/app/models/springshare/libanswers/ticket.rb
@@ -4,10 +4,6 @@ class Springshare::Libanswers::Ticket < Springshare::Libanswers::Base
     :details, :name, :email, :pennkey, :penn_id
   ]
 
-  # Specify how time intervals should show up
-  attribute :time_to_first_reply, :interval
-  attribute :time_to_close, :interval
-
   # Define an alternate name for an id
   # To correct the id named on upload
   def self.alternate_id


### PR DESCRIPTION
Remove attribute - needed for rails 6 but not for rails 7?